### PR TITLE
Don't force target, otherwise cl wont find the stdlib on windows

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -37,9 +37,6 @@ fn main() {
         .rust_target(bindgen::RustTarget::Stable_1_71)
         .formatter(bindgen::Formatter::Rustfmt);
 
-    #[cfg(windows)]
-    let bindings = bindings.clang_args(&["--target=x86_64-pc-windows-gnu"]);
-
     let bindings = bindings.generate().expect("Unable to generate bindings");
 
     // Redefine some Janet configs using environment variables


### PR DESCRIPTION
I played around with the build script a bit and the problem seems to be that you're passing a target which cl.exe can't find the standard headers for. Removing the target allows the crate to compile under windows. I haven't tried if it works yet (have to set up my build so it pulls the right version) but its a step in the right direction.