### PR TITLE
Update bindgen version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,8 +44,8 @@ debug-symbols = []
 libc = "0.2"
 
 [build-dependencies]
-bindgen = { version = "0.70.0", no-default-features = true, features = [
+bindgen = { version = "0.72.1", no-default-features = true, features = [
+  "prettyplease",
   "runtime",
-  "which-rustfmt",
 ] }
 cc = "1.0"

--- a/build.rs
+++ b/build.rs
@@ -34,7 +34,7 @@ fn main() {
         .allowlist_function(allowlist_regex)
         .allowlist_var(allowlist_regex)
         .override_abi(bindgen::Abi::CUnwind, allowlist_regex)
-        .rust_target(bindgen::RustTarget::Stable_1_71)
+        .rust_target(bindgen::RustTarget::stable(71, 0).expect("Missing rust target"))
         .formatter(bindgen::Formatter::Rustfmt);
 
     #[cfg(windows)]


### PR DESCRIPTION
This addresses a problem where newer libclang versions incorrectly create opaque structs, which means upstream crates like `janetrs` can't build using libclang 22. See https://github.com/rust-lang/rust-bindgen/pull/3278